### PR TITLE
Fix RustChain branding in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,7 +295,7 @@ curl -sS "https://YOUR-NODE/epoch"
 
 **[Elyan Labs](https://github.com/Scottcjn)** · 1,882 commits · 97 repos · 1,334 stars · $0 raised
 
-[⭐ Star Rustchain](https://github.com/Scottcjn/Rustchain) · [📊 Q1 2026 Traction Report](https://github.com/Scottcjn/Rustchain/blob/main/docs/DEVELOPER_TRACTION_Q1_2026.md) · [Follow @Scottcjn](https://github.com/Scottcjn)
+[⭐ Star RustChain](https://github.com/Scottcjn/Rustchain) · [📊 Q1 2026 Traction Report](https://github.com/Scottcjn/Rustchain/blob/main/docs/DEVELOPER_TRACTION_Q1_2026.md) · [Follow @Scottcjn](https://github.com/Scottcjn)
 
 </div>
 


### PR DESCRIPTION
## Summary

- Fix README link text from `Star Rustchain` to `Star RustChain` for consistent project branding.

Bounty: https://github.com/Scottcjn/rustchain-bounties/issues/2178

## Validation

- `git diff --check`
