### PR TITLE
fix(verify): balances positive-check silently degrades to row-count on canonical schema

### DIFF
--- a/tests/test_verify_backup_helpers.py
+++ b/tests/test_verify_backup_helpers.py
@@ -78,6 +78,24 @@ def test_get_table_info_detects_positive_balances_with_amount_and_value_columns(
     assert value_info == {"exists": True, "row_count": 1, "has_positive": True}
 
 
+def test_get_table_info_detects_positive_balances_with_amount_i64_column(tmp_path):
+    # Regression: production rustchain_v2.db names the column amount_i64, not
+    # amount/balance/value. Before this fix the whitelist omitted it, so
+    # get_table_info fell through to the row-count fallback against the real
+    # schema -- reproducing the exact bug #57 was meant to close.
+    db = tmp_path / "amount_i64.db"
+    conn = sqlite3.connect(db)
+    conn.execute("CREATE TABLE balances (amount_i64 INTEGER)")
+    conn.execute("INSERT INTO balances (amount_i64) VALUES (0)")
+    conn.execute("INSERT INTO balances (amount_i64) VALUES (0)")
+    conn.commit()
+    conn.close()
+
+    info = verify_backup.get_table_info(str(db), "balances")
+
+    assert info == {"exists": True, "row_count": 2, "has_positive": False}
+
+
 def test_get_table_info_rejects_all_zero_balances(tmp_path):
     # Regression: canonical schema is balances(amount). A backup whose balances
     # are all zero (or negative) must report has_positive=False, otherwise

--- a/tests/test_verify_backup_helpers.py
+++ b/tests/test_verify_backup_helpers.py
@@ -78,6 +78,24 @@ def test_get_table_info_detects_positive_balances_with_amount_and_value_columns(
     assert value_info == {"exists": True, "row_count": 1, "has_positive": True}
 
 
+def test_get_table_info_rejects_all_zero_balances(tmp_path):
+    # Regression: canonical schema is balances(amount). A backup whose balances
+    # are all zero (or negative) must report has_positive=False, otherwise
+    # verify_tables' check_positive requirement is defeated and a wiped backup
+    # passes verification.
+    zero_db = tmp_path / "zero.db"
+    conn = sqlite3.connect(zero_db)
+    conn.execute("CREATE TABLE balances (amount REAL)")
+    conn.execute("INSERT INTO balances (amount) VALUES (0)")
+    conn.execute("INSERT INTO balances (amount) VALUES (0)")
+    conn.commit()
+    conn.close()
+
+    info = verify_backup.get_table_info(str(zero_db), "balances")
+
+    assert info == {"exists": True, "row_count": 2, "has_positive": False}
+
+
 def test_verify_tables_passes_minimal_valid_backup_without_live_db(tmp_path):
     backup_db = tmp_path / "backup.db"
     _create_required_schema(backup_db)

--- a/verify_backup.py
+++ b/verify_backup.py
@@ -129,20 +129,29 @@ def get_table_info(db_path: str, table: str) -> Dict:
         cursor.execute(f"SELECT COUNT(*) FROM {table}")
         info["row_count"] = cursor.fetchone()[0]
         
-        # For balances, check for positive amounts
+        # For balances, check for positive amounts.
+        # The amount column can be named amount/balance/value depending on the
+        # schema version. SQLite validates every referenced column at prepare
+        # time, so a single query that names all of them (e.g. "amount > 0 OR
+        # balance > 0") raises "no such column" whenever the table has only one
+        # of them -- which is the normal case (canonical schema is
+        # balances(amount)). That error silently fell through to a row-count
+        # fallback, so a wiped/all-zero balances table was reported as having a
+        # positive balance and passed verification. Detect the real column via
+        # PRAGMA and query only that one.
         if table == "balances":
-            try:
-                cursor.execute(
-                    "SELECT COUNT(*) FROM balances WHERE amount > 0 OR balance > 0"
-                )
+            cursor.execute("PRAGMA table_info(balances)")
+            columns = {row[1] for row in cursor.fetchall()}
+            amount_col = next(
+                (c for c in ("amount", "balance", "value") if c in columns), None
+            )
+            if amount_col:
+                # amount_col comes from a fixed whitelist confirmed present in
+                # the table, so this f-string is not user-controlled.
+                cursor.execute(f"SELECT COUNT(*) FROM balances WHERE {amount_col} > 0")
                 info["has_positive"] = cursor.fetchone()[0] > 0
-            except sqlite3.Error:
-                # Column name might differ, try alternatives
-                try:
-                    cursor.execute("SELECT COUNT(*) FROM balances WHERE value > 0")
-                    info["has_positive"] = cursor.fetchone()[0] > 0
-                except sqlite3.Error:
-                    info["has_positive"] = info["row_count"] > 0
+            else:
+                info["has_positive"] = info["row_count"] > 0
         
         conn.close()
     except sqlite3.Error as e:

--- a/verify_backup.py
+++ b/verify_backup.py
@@ -130,20 +130,21 @@ def get_table_info(db_path: str, table: str) -> Dict:
         info["row_count"] = cursor.fetchone()[0]
         
         # For balances, check for positive amounts.
-        # The amount column can be named amount/balance/value depending on the
-        # schema version. SQLite validates every referenced column at prepare
+        # The amount column can be named amount_i64/amount/balance/value
+        # depending on the schema version (production rustchain_v2.db uses
+        # amount_i64). SQLite validates every referenced column at prepare
         # time, so a single query that names all of them (e.g. "amount > 0 OR
         # balance > 0") raises "no such column" whenever the table has only one
-        # of them -- which is the normal case (canonical schema is
-        # balances(amount)). That error silently fell through to a row-count
-        # fallback, so a wiped/all-zero balances table was reported as having a
-        # positive balance and passed verification. Detect the real column via
-        # PRAGMA and query only that one.
+        # of them -- which is the normal case. That error silently fell
+        # through to a row-count fallback, so a wiped/all-zero balances table
+        # was reported as having a positive balance and passed verification.
+        # Detect the real column via PRAGMA and query only that one.
         if table == "balances":
             cursor.execute("PRAGMA table_info(balances)")
             columns = {row[1] for row in cursor.fetchall()}
             amount_col = next(
-                (c for c in ("amount", "balance", "value") if c in columns), None
+                (c for c in ("amount_i64", "amount", "balance", "value") if c in columns),
+                None,
             )
             if amount_col:
                 # amount_col comes from a fixed whitelist confirmed present in


### PR DESCRIPTION
## Description
`get_table_info` decides `has_positive` for the `balances` table with a single query that names two columns:

```python
SELECT COUNT(*) FROM balances WHERE amount > 0 OR balance > 0
```

SQLite validates **every** referenced column at prepare time, so on the canonical schema `balances(amount)` — which has no `balance` column — this raises `no such column: balance`. The `except` path then tries `value > 0` (also absent) and finally falls back to `info["has_positive"] = info["row_count"] > 0`.

**Net effect:** `has_positive` is decided by row count, not by whether any balance is actually positive. A wiped / all-zero / negative `balances` table is reported `has_positive=True` and passes `verify_tables` `check_positive` requirement — defeating the point of the backup verifier (bounty #755).

Repro (canonical schema, two all-zero rows):
```
get_table_info -> {"exists": True, "row_count": 2, "has_positive": True}   # wrong, should be False
```
The existing test `test_get_table_info_detects_positive_balances_with_amount_and_value_columns` only passes because of the row-count fallback (its rows are non-empty), so it masks the defect — the amount check never actually executes.

## Type of Change
- [x] Bug fix

## Testing
Read the real column via `PRAGMA table_info(balances)` and query only the column that exists (`amount`/`balance`/`value`), falling back to row-count only when none are present. The whitelisted column name makes the f-string injection-safe.

- Added regression test `test_get_table_info_rejects_all_zero_balances` (all-zero `balances(amount)` → `has_positive=False`).
- Full `tests/test_verify_backup_helpers.py` suite: **8 passed**.

## Bounty Claim
- Issue number: #755 (Automated Backup Verification)
- Wallet ID: RTCd1554f0f35576faf01d386a6be1c947f560dd0b7